### PR TITLE
fix: Invalid 'end_col': out of range

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -247,7 +247,7 @@ end
 core.send_line = function()
   local linenr = vim.api.nvim_win_get_cursor(0)[1] - 1
   local cur_line = vim.api.nvim_buf_get_lines(0, linenr, linenr + 1, 0)[1]
-  local width = vim.fn.strdisplaywidth(cur_line)
+  local width = vim.fn.strwidth(cur_line)
 
   if width == 0 then return end
 
@@ -268,7 +268,7 @@ core.send_until_cursor = function()
   local linenr = vim.api.nvim_win_get_cursor(0)[1] - 1
   local text_until_line = vim.api.nvim_buf_get_lines(0, 0, linenr + 1, 0)
   local last_line = vim.api.nvim_buf_get_lines(0, linenr, linenr + 1, 0)[1]
-  local last_line_width = vim.fn.strdisplaywidth(last_line)
+  local last_line_width = vim.fn.strwidth(last_line)
 
   marks.set {
     from_line = 0,
@@ -306,11 +306,11 @@ core.mark_visual = function()
     local b_offset = math.max(1, b_col) - 1
     for ix, line in ipairs(lines) do
       -- On a block, remove all preciding chars unless b_col is 0/negative
-      lines[ix] = vim.fn.strcharpart(line, b_offset , math.min(e_col, vim.fn.strdisplaywidth(line)))
+      lines[ix] = vim.fn.strcharpart(line, b_offset , math.min(e_col, vim.fn.strwidth(line)))
     end
   elseif mode == "v" then
     local last = #lines
-    local line_size = vim.fn.strdisplaywidth(lines[last])
+    local line_size = vim.fn.strwidth(lines[last])
     local max_width = math.min(e_col, line_size)
     if (max_width < line_size) then
       -- If the selected width is smaller then total line, trim the excess
@@ -327,7 +327,7 @@ core.mark_visual = function()
     from_line = b_line - 1,
     from_col = math.max(b_col - 1, 0),
     to_line = e_line - 1,
-    to_col = math.min(e_col, vim.fn.strdisplaywidth(lines[#lines])) - 1 -- TODO Check whether this is actually true
+    to_col = math.min(e_col, vim.fn.strwidth(lines[#lines])) - 1 -- TODO Check whether this is actually true
   }
 
   if config.ignore_blank_lines then
@@ -357,7 +357,7 @@ core.mark_motion = function(mtype)
   if #lines == 0 then return end
 
   if mtype=='line' then
-    b_col, e_col = 0, vim.fn.strdisplaywidth(lines[#lines])
+    b_col, e_col = 0, vim.fn.strwidth(lines[#lines])
   end
 
   if e_col > 1 then
@@ -408,14 +408,14 @@ core.send_mark = function()
   local lines = vim.api.nvim_buf_get_lines(0, pos.from_line, pos.to_line + 1, 0)
 
   if #lines == 1 then
-    if pos.from_col >= 1 or pos.to_col < vim.fn.strdisplaywidth(lines[1]) - 1 then
+    if pos.from_col >= 1 or pos.to_col < vim.fn.strwidth(lines[1]) - 1 then
       lines[1] = vim.fn.strpart(lines[1], pos.from_col, pos.to_col - pos.from_col + 1)
     end
   else
     if pos.from_col >= 1 then
       lines[1] = vim.fn.strpart(lines[1], pos.from_col)
     end
-    if pos.to_col < vim.fn.strdisplaywidth(lines[#lines]) - 1 then
+    if pos.to_col < vim.fn.strwidth(lines[#lines]) - 1 then
       lines[#lines] = vim.fn.strpart(lines[#lines], 0, pos.to_col + 1)
     end
   end


### PR DESCRIPTION
`Invalid 'end_col': out of range` will be triggered when the last line of the code to be executed contains `<TAB>`, such as not using a specific number of spaces instead of `<TAB>`: `expandtab=true tabstop=4 `.